### PR TITLE
Small bugfix for small k and that created odd hashmaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 dependency-reduced-pom.xml
+.idea

--- a/src/main/scala/io/radanalytics/equoid/topk.scala
+++ b/src/main/scala/io/radanalytics/equoid/topk.scala
@@ -4,7 +4,6 @@
 
 package io.radanalytics.equoid
 
-import scala.util.Random
 import org.apache.spark.util.sketch.CountMinSketch
 
 import scala.collection.immutable
@@ -23,8 +22,8 @@ class TopK[V] (
     val ucms: CountMinSketch = ecms.mergeInPlace(this.cms)
     ucms.add(v, 1)
     val vf = ucms.estimateCount(v).toInt
-    val (utopk, ufmin) = if (topk.size < k) {
-      (topk + (v -> vf), math.min(vf, fmin))
+    val (utopk, ufmin) = if (topk.size < k || topk.contains(v)) {
+      (topk + (v -> vf), vf)
     } else if (vf <= fmin) (topk, fmin) else {
       val del = topk.minBy { case (_, f) => f }
       ((topk - del._1) + ((v, vf)), topk.values.min)
@@ -37,19 +36,17 @@ class TopK[V] (
     val ecms: CountMinSketch = CountMinSketch.create(epsilon, confidence, 13)
     val thatcms = ecms.mergeInPlace(that.cms) 
     val ucms = thatcms.mergeInPlace(this.cms)
-    val vu: Set[V] = this.topk.keys.toSet ++ that.topk.keys.toSet
-    val (utopk, ufmin) = vu.foldLeft((immutable.Map.empty[V, Int], 0)) { case ((tk, fm), v) =>
-      val vf = ucms.estimateCount(v).toInt
-      if (tk.size < k) {
-        (tk + (v -> vf), math.min(vf, fm))
-      } else if (vf <= fm) (tk, fm) else {
-        val del = tk.minBy { case (_, f) => f }
-        val mintk = (tk - del._1) + (v -> vf)
-        (mintk, mintk.values.min)
-      }
-    }
+
+    val utopk: immutable.Map[V, Int] = (this.topk.keys.toSet ++ that.topk.keys.toSet).map(key => {
+      (key -> ucms.estimateCount(key).toInt)
+    }).toVector.sortBy(- _._2).take(k).toMap
+    val ufmin = utopk.values.min
     new TopK[V](k, ucms, utopk, ufmin, epsilon, confidence)
   }
+
+  def top(n: Int): immutable.SortedMap[V, Int] = throw new NotImplementedError
+
+  override def toString: String = throw new NotImplementedError
 }
 
 // eps, confidence, seed


### PR DESCRIPTION
I think the `math.min(vf, fmin)` -> `vf` change can't hurt, because the object is always created with `k=0` and k can only grow in time