### PR TITLE
new TopK methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target
 dependency-reduced-pom.xml
 .idea
+*.iml
+build.sbt
+.history

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.8

--- a/project/build.scala
+++ b/project/build.scala
@@ -1,0 +1,2 @@
+import sbt._
+object MyBuild extends com.typesafe.sbt.pom.PomBuild

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-pom-reader" % "2.0.0")

--- a/src/test/scala/io/radanalytics/equoid/TopKTest.scala
+++ b/src/test/scala/io/radanalytics/equoid/TopKTest.scala
@@ -30,6 +30,17 @@ class TopKTest extends FlatSpec {
     assert(topK1.topk == topK2.topk)
   }
 
+  "The fmin" should "be correctly calculated" in {
+    val topK1 = helperTopk(6, 20)
+    val topK2 = helperTopk(1, 4)
+    val topK3 = helperTopk(5, 13)
+    val topK4 = helperTopk(5, 14)
+    assert(topK1.fmin == 11)
+    assert(topK2.fmin == 0)
+    assert(topK3.fmin == 0)
+    assert(topK4.fmin == 5)
+  }
+
   "Adding the same element twice" should "increase the frequency" in {
     val element = "Kpot"
     val nothing = empty[String]


### PR DESCRIPTION
This PR does these 4 things:

- Adding two methods to TopK class (`toString` and `top(n)`) 
- fixing small bug in `TopK.+` method for calculating `fmin`
- tests for `topk.fmin`
- sbt that works with `pom.xml`

For using sbt just type sbt and it should take the dependencies from the `pom.xml`. For this purpose we use https://github.com/sbt/sbt-pom-reader

Sorry for mixing topics into single PR