### PR TITLE
add assembly sbt target

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ def commonSettings = Seq(
     "org.infinispan" % "infinispan-core" % "9.1.4.Final",
     "org.infinispan" % "infinispan-client-hotrod" % "9.1.4.Final",
     "org.infinispan" %% "infinispan-spark" % "0.6",    
-    "io.radanalytics" %% "spark-streaming-amqp" % "0.3.1",
+    ("io.radanalytics" %% "spark-streaming-amqp" % "0.3.1").exclude("com.fasterxml.jackson.core", "jackson-databind"),
     "org.apache.spark" %% "spark-core" % sparkVersion % Provided,
     "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
     "org.apache.spark" %% "spark-streaming" % sparkVersion % Provided,
@@ -27,3 +27,22 @@ def commonSettings = Seq(
 )
 
 seq(commonSettings:_*)
+
+test in assembly := {}
+
+// not sure what strategy to use for these
+// see https://github.com/sbt/sbt-assembly
+assemblyMergeStrategy in assembly := {
+  case "META-INF/DEPENDENCIES.txt" => MergeStrategy.discard
+  case "META-INF/io.netty.versions.properties" => MergeStrategy.discard
+  case "features.xml" => MergeStrategy.discard
+  case x =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
+}
+
+assemblyShadeRules in assembly := Seq(
+  // ShadeRule.zap("scala.**").inAll,
+  // ShadeRule.zap("org.slf4j.**").inAll
+)
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")


### PR DESCRIPTION
I got the assembly target to build by excluding the `jackson-databind` dep from `spark-streaming-amqp`.

I also applied some merge strategy customizations for some meta-inf, which discard the conflicting files. If just discarding turns out to be the wrong answer there are other strategies available:
https://github.com/sbt/sbt-assembly

Tests pass, but this will probably require manual testing with a deployment.