### PR TITLE
getProp now accepts the name of the property in the SNAKE_CASE

### DIFF
--- a/src/main/scala/io/radanalytics/equoid/CheckCache.scala
+++ b/src/main/scala/io/radanalytics/equoid/CheckCache.scala
@@ -1,32 +1,14 @@
 package io.radanalytics.equoid
 
-import java.lang.Long
-
-import io.radanalytics.equoid._
-
-import scala.util.Random
-
-import org.infinispan._
-import org.infinispan.client.hotrod.RemoteCache
 import org.infinispan.client.hotrod.RemoteCacheManager
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder
-import org.infinispan.client.hotrod.configuration.Configuration
-import org.infinispan.client.hotrod.impl.ConfigurationProperties
-
-import scala.collection.immutable
-import scala.util.Properties
 
 object CheckCache {
 
-  def getProp(camelCaseName: String, defaultValue: String): String = {
-        val snakeCaseName = camelCaseName.replaceAll("(.)(\\p{Upper})", "$1_$2").toUpperCase()
-            Properties.envOrElse(snakeCaseName, Properties.scalaPropOrElse(snakeCaseName, defaultValue))
-              }  
-
   def main(args: Array[String]): Unit = {
-    val infinispanHost = getProp("jdgHost", "datagrid-hotrod")
-    val infinispanPort = getProp("jdgPort", "11222").toInt
-    val iterations = getProp("ccIter", "15").toInt
+    val infinispanHost = getProp("JDG_HOST", "datagrid-hotrod")
+    val infinispanPort = getProp("JDG_PORT", "11222").toInt
+    val iterations = getProp("CC_ITER", "15").toInt
     
     val builder: ConfigurationBuilder = new ConfigurationBuilder()
     builder.addServer().host(infinispanHost).port(infinispanPort)

--- a/src/main/scala/io/radanalytics/equoid/DataHandler.scala
+++ b/src/main/scala/io/radanalytics/equoid/DataHandler.scala
@@ -1,46 +1,17 @@
 package io.radanalytics.equoid
 
-import java.lang.Long
-
-import io.radanalytics.streaming.amqp.AMQPJsonFunction
-import io.vertx.core.{AsyncResult, Handler, Vertx}
-import io.vertx.proton._
-import org.apache.log4j.{Level, LogManager, PropertyConfigurator, Logger}
-
-import org.apache.qpid.proton.amqp.messaging.{AmqpValue, Data}
+import org.apache.qpid.proton.amqp.messaging.AmqpValue
 import org.apache.qpid.proton.message.Message
 import org.apache.spark.SparkConf
-import org.apache.spark.SparkContext
 import org.apache.spark.storage.StorageLevel
-import org.apache.spark.rdd
 import org.apache.spark.streaming.amqp.AMQPUtils
-import org.apache.spark.streaming.{Duration, Seconds, StreamingContext}
-
-import org.apache.spark.util.sketch.CountMinSketch
-import io.radanalytics.equoid._
-import org.apache.spark.sql.SparkSession
-
-import org.apache.spark.util.sketch
-import org.apache.spark.util.LongAccumulator
-import scala.util.Random
-import scala.util.Properties
-
-import org.infinispan._
-import org.infinispan.client.hotrod.RemoteCache
+import org.apache.spark.streaming.{Seconds, StreamingContext}
 import org.infinispan.client.hotrod.RemoteCacheManager
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder
-import org.infinispan.client.hotrod.impl.ConfigurationProperties
-
-import scala.collection.immutable
 
 object DataHandler {
 
   private val checkpointDir: String = "/tmp/equoid-data-handler"
-
-  def getProp(camelCaseName: String, defaultValue: String): String = {
-    val snakeCaseName = camelCaseName.replaceAll("(.)(\\p{Upper})", "$1_$2").toUpperCase()
-    Properties.envOrElse(snakeCaseName, Properties.scalaPropOrElse(snakeCaseName, defaultValue))
-  }  
   
   def main(args: Array[String]): Unit = {
 
@@ -75,19 +46,19 @@ object DataHandler {
   }
 
   def createStreamingContext(): StreamingContext = {
-    val amqpHost = getProp("amqpHost", "broker-amq-amqp")
-    val amqpPort = getProp("amqpPort", "5672").toInt
-    val username = Option(getProp("amqpUsername", "daikon"))
-    val password = Option(getProp("amqpPassword", "daikon"))
-    val address = getProp("queueName", "salesq")
-    val infinispanHost = getProp("jdgHost", "datagrid-hotrod")
-    val infinispanPort = getProp("jdgPort", "11222").toInt
-    val k = getProp("cmsK", "3").toInt
-    val epsilon = getProp("cmsEpsilon", "0.01").toDouble
-    val confidence = getProp("cmsConfidence", "0.9").toDouble   
-    val windowSeconds = getProp("windowSeconds", "30").toInt
-    val slideSeconds = getProp("slideSeconds", "30").toInt
-    val sparkMaster = getProp("sparkMaster", "spark://sparky:7077")
+    val amqpHost = getProp("AMQP_HOST", "broker-amq-amqp")
+    val amqpPort = getProp("AMQP_PORT", "5672").toInt
+    val username = Option(getProp("AMQP_USERNAME", "daikon"))
+    val password = Option(getProp("AMQP_PASSWORD", "daikon"))
+    val address = getProp("QUEUE_NAME", "salesq")
+    val infinispanHost = getProp("JDG_HOST", "datagrid-hotrod")
+    val infinispanPort = getProp("JDG_PORT", "11222").toInt
+    val k = getProp("CMS_K", "3").toInt
+    val epsilon = getProp("CMS_EPSILON", "0.01").toDouble
+    val confidence = getProp("CMS_CONFIDENCE", "0.9").toDouble
+    val windowSeconds = getProp("WINDOW_SECONDS", "30").toInt
+    val slideSeconds = getProp("SLIDE_SECONDS", "30").toInt
+    val sparkMaster = getProp("SPARK_MASTER", "spark://sparky:7077")
     val conf = new SparkConf().setMaster(sparkMaster).setAppName(getClass().getSimpleName())
     conf.set("spark.streaming.receiver.writeAheadLog.enable", "true")
     

--- a/src/main/scala/io/radanalytics/equoid/FileDataHandler.scala
+++ b/src/main/scala/io/radanalytics/equoid/FileDataHandler.scala
@@ -2,31 +2,13 @@ package io.radanalytics.equoid
 
 import java.lang.Long
 
-import org.apache.log4j.{Level, LogManager, PropertyConfigurator, Logger}
-
-import org.apache.spark.SparkConf
-import org.apache.spark.SparkContext
-import org.apache.spark.storage.StorageLevel
-import org.apache.spark.rdd
-import org.apache.spark.streaming.amqp.AMQPUtils
-import org.apache.spark.streaming.{Duration, Seconds, StreamingContext}
-
-import org.apache.spark.util.sketch.CountMinSketch
-import io.radanalytics.equoid._
-import org.apache.spark.sql.SparkSession
-
-import org.apache.spark.util.sketch
+import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.spark.streaming.{Seconds, StreamingContext}
 import org.apache.spark.util.LongAccumulator
-import scala.util.Random
-import scala.util.Properties
-
-import org.infinispan._
-import org.infinispan.client.hotrod.RemoteCache
 import org.infinispan.client.hotrod.RemoteCacheManager
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder
-import org.infinispan.client.hotrod.impl.ConfigurationProperties
 
-import scala.collection.immutable
+import scala.util.Properties
 
 object FileIntervalAccumulator {
 
@@ -81,11 +63,11 @@ object FileDataHandler {
   }
 
   def createStreamingContext(): StreamingContext = {
-    val infinispanHost = getProp("jdgHost", "localhost")
-    val infinispanPort = getProp("jdgPort", "11222").toInt
-    val k = getProp("cmsK", "3").toInt
-    val epsilon = getProp("cmsEpsilon", "0.01").toDouble
-    val confidence = getProp("cmsConfidence", "0.9").toDouble    
+    val infinispanHost = getProp("JDG_HOST", "localhost")
+    val infinispanPort = getProp("JDG_PORT", "11222").toInt
+    val k = getProp("CMS_K", "3").toInt
+    val epsilon = getProp("CMS_EPSILON", "0.01").toDouble
+    val confidence = getProp("CMS_CONFIDENCE", "0.9").toDouble
     val conf = new SparkConf().setMaster(master).setAppName(appName)
     conf.set("spark.streaming.receiver.writeAheadLog.enable", "true")
     

--- a/src/main/scala/io/radanalytics/equoid/TopK.scala
+++ b/src/main/scala/io/radanalytics/equoid/TopK.scala
@@ -6,8 +6,6 @@ package io.radanalytics.equoid
 
 import org.apache.spark.util.sketch.CountMinSketch
 
-import scala.collection.immutable
-
 class TopK[V] ( 
   val k: Int,
   val cms: CountMinSketch,

--- a/src/main/scala/io/radanalytics/equoid/package.scala
+++ b/src/main/scala/io/radanalytics/equoid/package.scala
@@ -1,0 +1,14 @@
+package io.radanalytics
+
+import scala.util.Properties
+
+package object equoid {
+  def getProp(snakeCaseName: String, defaultValue: String): String = {
+    // return the value of 'SNAKE_CASE_NAME' env variable,
+    // if ^ not defined, return the value of 'snakeCaseName' JVM property
+    // if ^ not defined, return the defaultValue
+    val camelCase = "_(.)".r.replaceAllIn(snakeCaseName.toLowerCase, m => m.group(1).toUpperCase)
+    Properties.envOrElse(snakeCaseName, Properties.propOrElse(camelCase, defaultValue))
+  }
+
+}


### PR DESCRIPTION
The semantics should be still the same. I.e. it tries to get the env. variable with this name, if it's not there it tries the system property, and if all fails it returns the `defaultValue` as fallback mechanism.

This PR also removes couple of unused imports

tests are in the publisher repo ([here](https://github.com/EldritchJS/equoid-data-publisher/pull/5/commits/e15f822560d582701a164d8a888efb51d85e8a0a))