### PR TITLE
Data mod

### DIFF
--- a/src/main/scala/io/radanalytics/equoid/DataHandler.scala
+++ b/src/main/scala/io/radanalytics/equoid/DataHandler.scala
@@ -27,10 +27,10 @@ object DataHandler {
     message.getBody match {
       case body: AmqpValue => {
         val itemID: String = body.getValue.asInstanceOf[String]
-        val primaryVal: String = itemID.split(",")(0)
+        //val primaryVal: String = itemID.split(",")(0)
         opMode match {
           case "linear" => Some(itemID)
-          case "single" => Some(primaryVal)
+          case "single" => Some(itemID.split(",")(0))
           case "dual" => Some(itemID)
           case x => { println(s"unexpected opMode"); None }
         }

--- a/src/main/scala/io/radanalytics/equoid/DataHandler.scala
+++ b/src/main/scala/io/radanalytics/equoid/DataHandler.scala
@@ -29,7 +29,7 @@ object DataHandler {
         val itemID: String = body.getValue.asInstanceOf[String]
         val primaryVal: String = itemID.split(",")(0)
         opMode match {
-          case "linear" => Some(primaryVal)
+          case "linear" => Some(itemID)
           case "single" => Some(primaryVal)
           case "dual" => Some(itemID)
           case x => { println(s"unexpected opMode"); None }

--- a/src/main/scala/io/radanalytics/equoid/DataHandler.scala
+++ b/src/main/scala/io/radanalytics/equoid/DataHandler.scala
@@ -28,8 +28,8 @@ object DataHandler {
       case body: AmqpValue => {
         val itemID: String = body.getValue.asInstanceOf[String]
         val primaryVal: String = itemID.split(",")(0)
-//        println(s"opMode: $opMode itemID: $itemID stockVal: $stockVal countryVal: $countryVal")
         opMode match {
+          case "linear" => Some(primaryVal)
           case "single" => Some(primaryVal)
           case "dual" => Some(itemID)
           case x => { println(s"unexpected opMode"); None }
@@ -57,7 +57,7 @@ object DataHandler {
     val amqpPort = getProp("AMQP_PORT", "5672").toInt
     val username = Option(getProp("AMQP_USERNAME", "daikon"))
     val password = Option(getProp("AMQP_PASSWORD", "daikon"))
-    val address = getProp("QUEUE_NAME", "salesq")
+    val address = getProp("QUEUE_NAME", "recordq")
     val infinispanHost = getProp("JDG_HOST", "datagrid-hotrod")
     val infinispanPort = getProp("JDG_PORT", "11222").toInt
     val k = getProp("CMS_K", "3").toInt

--- a/src/main/scala/io/radanalytics/equoid/DataHandler.scala
+++ b/src/main/scala/io/radanalytics/equoid/DataHandler.scala
@@ -12,10 +12,8 @@ import org.infinispan.client.hotrod.configuration.ConfigurationBuilder
 object DataHandler {
 
   private val checkpointDir: String = "/tmp/equoid-data-handler"
-  var opMode: String = ""
 
   def main(args: Array[String]): Unit = {
-    opMode = getProp("OP_MODE", "stock");
     val ssc = StreamingContext.getOrCreate(checkpointDir, createStreamingContext)
     ssc.sparkContext.setLogLevel("ERROR")
     
@@ -25,6 +23,7 @@ object DataHandler {
   }
 
   def messageConverter(message: Message): Option[String] = {
+    val opMode = getProp("OP_MODE", "stock");
 
     message.getBody match {
       case body: AmqpValue => {

--- a/src/main/scala/io/radanalytics/equoid/DataHandler.scala
+++ b/src/main/scala/io/radanalytics/equoid/DataHandler.scala
@@ -23,12 +23,14 @@ object DataHandler {
     ssc.stop()
   }
 
+  /* TODO: Modify this to parse incoming message */
   def messageConverter(message: Message): Option[String] = {
 
     message.getBody match {
       case body: AmqpValue => {
         val itemID: String = body.getValue.asInstanceOf[String]
-        Some(itemID)
+        val fieldVal = itemID.split(",")
+        Some(fieldVal(0))
       }
       case x => { println(s"unexpected type ${x.getClass.getName}"); None }
     }
@@ -61,6 +63,7 @@ object DataHandler {
     val windowSeconds = getProp("WINDOW_SECONDS", "30").toInt
     val slideSeconds = getProp("SLIDE_SECONDS", "30").toInt
     val batchSeconds = getProp("SLIDE_SECONDS", "30").toInt
+    val fieldOfInterest = getProp("FIELD_INDEX", "0").toInt;
 
     // store something in the JDG for this interval so that we can give something quickly to the user
     storeTopK(windowSeconds.toString, Vector(("nothing", 0)), infinispanHost, infinispanPort)

--- a/src/main/scala/io/radanalytics/equoid/DataHandler.scala
+++ b/src/main/scala/io/radanalytics/equoid/DataHandler.scala
@@ -32,9 +32,9 @@ object DataHandler {
         val stockVal: String = itemID.split(",")(0)
         val countryVal: String = itemID.split(",")(1)
         opMode match {
-          case "Stock" => Some(stockVal)
-          case "Country" => Some(countryVal)
-          case "StockByCountry" => Some(itemID)
+          case "stock" => Some(stockVal)
+          case "country" => Some(countryVal)
+          case "stockbycountry" => Some(itemID)
           case x => { println(s"unexpected opMode"); None }
         }
       }

--- a/src/main/scala/io/radanalytics/equoid/DataHandler.scala
+++ b/src/main/scala/io/radanalytics/equoid/DataHandler.scala
@@ -27,13 +27,11 @@ object DataHandler {
     message.getBody match {
       case body: AmqpValue => {
         val itemID: String = body.getValue.asInstanceOf[String]
-        val stockVal: String = itemID.split(",")(0)
-        val countryVal: String = itemID.split(",")(1)
-        println(s"opMode: $opMode itemID: $itemID stockVal: $stockVal countryVal: $countryVal")
+        val primaryVal: String = itemID.split(",")(0)
+//        println(s"opMode: $opMode itemID: $itemID stockVal: $stockVal countryVal: $countryVal")
         opMode match {
-          case "stock" => Some(stockVal)
-          case "country" => Some(countryVal)
-          case "stockbycountry" => Some(itemID)
+          case "single" => Some(primaryVal)
+          case "dual" => Some(itemID)
           case x => { println(s"unexpected opMode"); None }
         }
       }
@@ -68,7 +66,7 @@ object DataHandler {
     val windowSeconds = getProp("WINDOW_SECONDS", "30").toInt
     val slideSeconds = getProp("SLIDE_SECONDS", "30").toInt
     val batchSeconds = getProp("SLIDE_SECONDS", "30").toInt
-    val opMode = getProp("OP_MODE", "stock")
+    val opMode = getProp("OP_MODE", "single")
     // store something in the JDG for this interval so that we can give something quickly to the user
     storeTopK(windowSeconds.toString, Vector(("nothing", 0)), infinispanHost, infinispanPort)
 

--- a/src/main/scala/io/radanalytics/equoid/DataHandler.scala
+++ b/src/main/scala/io/radanalytics/equoid/DataHandler.scala
@@ -15,7 +15,7 @@ object DataHandler {
   var opMode: String = ""
 
   def main(args: Array[String]): Unit = {
-
+    opMode = getProp("OP_MODE", "stock");
     val ssc = StreamingContext.getOrCreate(checkpointDir, createStreamingContext)
     ssc.sparkContext.setLogLevel("ERROR")
     
@@ -69,7 +69,6 @@ object DataHandler {
     val windowSeconds = getProp("WINDOW_SECONDS", "30").toInt
     val slideSeconds = getProp("SLIDE_SECONDS", "30").toInt
     val batchSeconds = getProp("SLIDE_SECONDS", "30").toInt
-    opMode = getProp("OP_MODE", "Stock");
 
     // store something in the JDG for this interval so that we can give something quickly to the user
     storeTopK(windowSeconds.toString, Vector(("nothing", 0)), infinispanHost, infinispanPort)

--- a/src/main/scala/io/radanalytics/equoid/DataHandler.scala
+++ b/src/main/scala/io/radanalytics/equoid/DataHandler.scala
@@ -31,6 +31,7 @@ object DataHandler {
         val itemID: String = body.getValue.asInstanceOf[String]
         val stockVal: String = itemID.split(",")(0)
         val countryVal: String = itemID.split(",")(1)
+        println(s"opMode: $opMode itemID: $itemID stockVal: $stockVal countryVal: $countryVal")
         opMode match {
           case "stock" => Some(stockVal)
           case "country" => Some(countryVal)


### PR DESCRIPTION
Modified data handler to accommodate three operating modes based on the value of OP_MODE env variable. Single mode takes either the first field (or just the entry if no separator) as its input message, while dual takes the full input as its value to be counted towards top-k. linear does the same as dual (included for consistency with data publisher) 